### PR TITLE
veto events in selection task

### DIFF
--- a/analysis_templates/ghent_template/__cf_module_name__/config/config___cf_short_name_lc__.py
+++ b/analysis_templates/ghent_template/__cf_module_name__/config/config___cf_short_name_lc__.py
@@ -16,6 +16,7 @@ from columnflow.config_util import (
 from __cf_short_name_lc__.config.styling import stylize_processes
 from __cf_short_name_lc__.config.datasets import add_datasets, configure_datasets
 from __cf_short_name_lc__.config.processes import add_processes
+from __cf_short_name_lc__.config.veto import add_vetoes
 from __cf_short_name_lc__.config.categories import add_categories_selection
 from __cf_short_name_lc__.config.variables import add_variables
 from __cf_short_name_lc__.config.shifts import add_shifts
@@ -56,6 +57,7 @@ def add_config(
 
     add_triggers(cfg, campaign)
     add_datasets(cfg, campaign)
+    add_vetoes(cfg)
     configure_datasets(cfg, limit_dataset_files)
 
     # verify that the root process of all datasets is part of any of the registered processes

--- a/analysis_templates/ghent_template/__cf_module_name__/config/veto.py
+++ b/analysis_templates/ghent_template/__cf_module_name__/config/veto.py
@@ -1,0 +1,16 @@
+import order as od
+
+from columnflow.util import call_once_on_config
+
+@call_once_on_config()
+def add_vetoes(config: od.Config) -> None:
+    config.x.veto = {
+        'dy_lep_m10to50_amcatnlo': [
+            {
+                "event": 33098036,
+                "luminosityBlock": 20170,
+                "run": 1,
+                "file": "/store/mc/RunIISummer20UL18NanoAODv9/DYJetsToLL_M-10to50_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/50000/296CA60E-0122-2F4F-8B04-17DCF5E3E062.root", # noqa
+            }
+        ]
+    }

--- a/analysis_templates/ghent_template/law.cfg
+++ b/analysis_templates/ghent_template/law.cfg
@@ -33,7 +33,7 @@ default_dataset: tt_sl_powheg
 
 calibration_modules: columnflow.calibration.cms.{jets,met}, __cf_module_name__.calibration.{default,jet}
 selection_modules: columnflow.selection.{empty}, columnflow.selection.cms.{json_filter, met_filters}, __cf_module_name__.selection.{default,categories,stats,trigger}
-production_modules: columnflow.production.{categories,normalization,processes}, columnflow.production.cms.{btag,electron,mc_weight,muon,pdf,pileup,scale,seeds}, __cf_module_name__.production.{weights,features,categories}
+production_modules: columnflow.production.{categories,normalization,processes,veto}, columnflow.production.cms.{btag,electron,mc_weight,muon,pdf,pileup,scale,seeds}, __cf_module_name__.production.{weights,features,categories}
 categorization_modules: __cf_module_name__.categorization.example
 ml_modules: columnflow.ml, __cf_module_name__.ml.example
 inference_modules: columnflow.inference, __cf_module_name__.inference.example

--- a/columnflow/production/veto.py
+++ b/columnflow/production/veto.py
@@ -10,7 +10,8 @@ np = maybe_import("numpy")
 
 
 @producer(
-    uses=("event", "run", "luminosityBlock"),
+    uses={"event", "run", "luminosityBlock"},
+    produces={"veto"},
     exposed=False,
     get_veto_file=(lambda self, external_files: external_files.veto),
 )

--- a/columnflow/production/veto.py
+++ b/columnflow/production/veto.py
@@ -1,0 +1,76 @@
+from collections import defaultdict
+
+from columnflow.production import Producer, producer
+from columnflow.util import maybe_import, InsertableDict
+from columnflow.columnar_util import set_ak_column
+from law import LocalFileTarget
+
+ak = maybe_import("awkward")
+np = maybe_import("numpy")
+
+
+@producer(
+    uses=("event", "run", "luminosityBlock"),
+    exposed=False,
+    get_veto_file=(lambda self, external_files: external_files.veto),
+)
+def veto_events(
+        self: Producer,
+        events: ak.Array,
+        file: LocalFileTarget = None,
+        **kwargs,
+) -> ak.Array:
+    """
+    Produces a mask vetoing certain events from being processed. Outputs a SelectionResult
+    with attributes *veto* (containing a mask selecting the vetoed events) and with the *event*
+    attribute initialized with a mask selecting non-vetoed events. If *file* is provided, it checks only
+    events contained within this file, or events not designated to any file.
+
+    The events that are vetoed need to be specified  from ``config_inst``,
+    which must contain the keyword ``veto`` in the auxiliary information. This can look
+    like this:
+
+    .. code-block:: python
+
+        # cfg is the current config instance
+        cfg.x.veto = config.x.veto = {
+            "dy_lep_m10to50_amcatnlo" : [
+                {
+                    "event": 33098036,
+                    "luminosityBlock": 20170,
+                    "run": 1,
+                    ** optionally **
+                    "file": "/store/mc/RunIISummer20UL18NanoAODv9/DYJetsToLL_M-10to50_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/50000/296CA60E-0122-2F4F-8B04-17DCF5E3E062.root"  # noqa
+                }
+            ]
+        }
+
+    """
+
+    veto = np.full_like(events.event, False, dtype=bool)
+    for veto_event in self.veto_list:
+        if file is None or "file" not in veto_event or file.path == veto_event["file"]:
+            veto = veto | (
+                     (events.event == veto_event['event']) &
+                     (events.run == veto_event['run']) &
+                     (events.luminosityBlock == veto_event['luminosityBlock'])
+                     )
+
+    events = set_ak_column(events, "veto", veto)
+
+    return events
+
+
+@veto_events.setup
+def veto_events_setup(
+        self: Producer,
+        reqs: dict,
+        inputs: dict,
+        reader_targets: InsertableDict,
+) -> None:
+    """
+    Loads the event veto file from the external files bundle and saves them in the
+    py:attr:`veto_list` attribute for simpler access in the actual callable.
+    """
+    veto_dict = self.config_inst.aux.get("veto", {})
+    self.veto_list = veto_dict.get(self.dataset_inst.name, [])

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -158,6 +158,7 @@ class SelectEvents(
         # define columns that will be written
         write_columns = set(map(Route, mandatory_coffea_columns))
         write_columns |= self.selector_inst.produced_columns
+        write_columns |= self.veto_producer.produced_columns
         route_filter = RouteFilter(write_columns)
 
         # let the lfn_task prepare the nano file (basically determine a good pfn)

--- a/law.cfg
+++ b/law.cfg
@@ -21,7 +21,7 @@ default_analysis: columnflow.example_config.analysis_st.analysis_st
 default_config: run2_pp_2018
 default_dataset: st_tchannel_t
 
-production_modules: columnflow.production.{categories,processes,normalization}
+production_modules: columnflow.production.{categories,processes,normalization,veto}
 calibration_modules: columnflow.calibration
 selection_modules: columnflow.selection.{empty}
 categorization_modules: columnflow.categorization


### PR DESCRIPTION
- veto mask is create with special [producer](https://github.com/GhentAnalysis/columnflow/blob/veto_dev/columnflow/production/veto.py)
- [SelectEvents task](https://github.com/GhentAnalysis/columnflow/blob/veto_dev/columnflow/tasks/selection.py) calls this producers, calculates event mask, and excludes vetoed events from checks on finitedness
- vetoed events can be accessed as events.veto. See [this commit](https://github.com/GhentAnalysis/columnflow/pull/6/commits/23010b27ad5bb354e03360b71ba4f2e6346c2bae) how to exclude the vetoed events from stats, and from event selection