### PR TITLE
add custom x tick labels

### DIFF
--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -217,6 +217,12 @@ def prepare_style_config(
         tx = range(int(xlim[0]), int(xlim[1]+1))
         style_config["ax_cfg"]["xticks"] = tx
         style_config["ax_cfg"]["minorxticks"] = []
+
+        # add custom bin labels if specified and same amount of x ticks
+        if x_labels := variable_inst.x_labels:
+            if len(x_labels) == len(tx):
+                style_config["ax_cfg"]["xticklabels"] = x_labels
+
     if variable_inst.discrete_y:
         style_config["ax_cfg"]["minoryticks"] = []
 


### PR DESCRIPTION
can be added in `add_variable` config option.

only allowed for discrete x in this implementation