### PR TITLE
add checks for event and object masks to avoid bugs going by unnoticed

### DIFF
--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -236,10 +236,10 @@ class SelectionResult(od.AuxDataMixin):
 
     @classmethod
     def check_valid_event_mask(cls, name, event_mask):
-        assert isinstance(event_mask, (np.ndarray, ak.Array)), f"{name} should be numpy or awkward array but is {type(event)}"
-        assert event_mask.ndim == 1, f"{name} array has illegal dimension {event.ndim}"
+        assert isinstance(event_mask, (np.ndarray, ak.Array)), f"{name} should be numpy or awkward array but is {type(event_mask)}"
+        assert event_mask.ndim == 1, f"{name} array has illegal dimension {event_mask.ndim}"
         assert np.array(event_mask).dtype == bool, f"{name} is {np.array(event_mask).dtype} array, not boolean array"
-        return cls.check_nones_and_convert(name, mask)
+        return cls.check_nones_and_convert(name, event_mask)
 
     def __init__(
         self: SelectionResult,
@@ -274,7 +274,7 @@ class SelectionResult(od.AuxDataMixin):
                         if dst_obj_mask.ndim == 1:
                             logger.info(f"converting 1d object mask {dst_obj} to 2d")
                             dst_obj_mask = dst_obj_mask[:, None]
-                        dst_object_mask = ak.from_regular(dst_obj_mask)  # make sure object masks are jagged to avoid numpy index
+                        dst_obj_mask = ak.from_regular(dst_obj_mask)  # make sure object masks are jagged to avoid numpy index
                     dst_objects[dst_obj] = dst_obj_mask
         self.objects = DotDict.wrap(objects or {})
         self.other = DotDict.wrap(other)

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -22,6 +22,7 @@ np = maybe_import("numpy")
 
 logger = law.logger.get_logger(__name__)
 
+
 class Selector(TaskArrayFunction):
     """
     Base class for all selectors.
@@ -228,7 +229,7 @@ class SelectionResult(od.AuxDataMixin):
     @classmethod
     def check_nones_and_convert(cls, name, mask):
         mask_type = str(mask.type)
-        if '?' in mask_type or 'Option' in mask_type:
+        if "?" in mask_type or "Option" in mask_type:
             assert not ak.any(ak.is_none(mask)), f"mask {name} contains None values"
             logger.info(f"mask {name} is of mixed type, but does not contain Nones: converting to pure type.")
             mask = ak.fill_none(mask, 0)
@@ -236,7 +237,7 @@ class SelectionResult(od.AuxDataMixin):
 
     @classmethod
     def check_valid_event_mask(cls, name, event_mask):
-        assert isinstance(event_mask, (np.ndarray, ak.Array)), f"{name} should be numpy or awkward array but is {type(event_mask)}"
+        assert isinstance(event_mask, (np.ndarray, ak.Array)), f"{name} should be array, not {type(event_mask)}"
         assert event_mask.ndim == 1, f"{name} array has illegal dimension {event_mask.ndim}"
         assert np.array(event_mask).dtype == bool, f"{name} is {np.array(event_mask).dtype} array, not boolean array"
         return cls.check_nones_and_convert(name, event_mask)
@@ -267,14 +268,15 @@ class SelectionResult(od.AuxDataMixin):
                     dst_obj_mask = self.check_nones_and_convert(dst_obj, dst_obj_mask)
 
                     dst_obj_mask_type = str(dst_obj_mask.type)
-                    if 'bool' in dst_obj_mask_type:
-                        assert dst_obj_mask.ndim == 2, f"boolean object mask {dst_obj} has illegal dimension {dst_obj_mask.ndim}"
-                    elif 'int' in dst_obj_mask_type:
-                        assert dst_obj_mask.ndim in [1, 2], f"integer object mask {dst_obj} has illegal dimension {dst_obj_mask.ndim}"
+                    if "bool" in dst_obj_mask_type:
+                        assert dst_obj_mask.ndim == 2, f"boolean mask {dst_obj} has illegal dim {dst_obj_mask.ndim}"
+                    elif "int" in dst_obj_mask_type:
+                        assert dst_obj_mask.ndim in [1, 2], f"int mask {dst_obj} has illegal dim {dst_obj_mask.ndim}"
                         if dst_obj_mask.ndim == 1:
                             logger.info(f"converting 1d object mask {dst_obj} to 2d")
                             dst_obj_mask = dst_obj_mask[:, None]
-                        dst_obj_mask = ak.from_regular(dst_obj_mask)  # make sure object masks are jagged to avoid numpy index
+                        # make sure object masks are jagged to avoid numpy index
+                        dst_obj_mask = ak.from_regular(dst_obj_mask)
                     dst_objects[dst_obj] = dst_obj_mask
         self.objects = DotDict.wrap(objects or {})
         self.other = DotDict.wrap(other)

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -18,7 +18,9 @@ from columnflow.columnar_util import TaskArrayFunction
 from columnflow.config_util import expand_shift_sources
 
 ak = maybe_import("awkward")
+np = maybe_import("numpy")
 
+logger = law.logger.get_logger(__name__)
 
 class Selector(TaskArrayFunction):
     """
@@ -223,6 +225,12 @@ class SelectionResult(od.AuxDataMixin):
         res.to_ak()
     """
 
+    @classmethod
+    def check_valid_event_mask(cls, name, event_mask):
+        assert isinstance(event_mask, (np.ndarray, ak.Array)), f"{name} should be numpy or awkward array but is {type(event)}"
+        assert event_mask.ndim == 1, f"{name} array has illegal dimension {event.ndim}"
+        assert np.array(event_mask).dtype == bool, f"{name} is {np.array(event_mask).dtype} array, not boolean array"
+
     def __init__(
         self: SelectionResult,
         event: ak.Array | None = None,
@@ -234,8 +242,30 @@ class SelectionResult(od.AuxDataMixin):
         super().__init__(aux=aux)
 
         # store fields
+        if event is not None:
+            self.check_valid_event_mask("event", event)
         self.event = event
+        if steps is not None:
+            for step in steps.items():
+                self.check_valid_event_mask(*step)
         self.steps = DotDict.wrap(steps or {})
+        if objects is not None:
+            for src_object, dst_objects in objects.items():
+                assert isinstance(dst_objects, (DotDict, dict)), "objects should be a (dot)dict of (dot)dicts"
+                for dst_obj, dst_obj_mask in dst_objects.items():
+                    dst_obj_mask_type = str(dst_obj_mask.type)
+                    if 'bool' in dst_obj_mask_type:
+                        assert dst_obj_mask.ndim == 2, f"boolean object mask {dst_obj} has illegal dimension {dst_obj_mask.ndim}"
+                    elif 'int' in dst_obj_mask_type:
+                        assert dst_obj_mask.ndim in [1, 2], f"integer object mask {dst_obj} has illegal dimension {dst_obj_mask.ndim}"
+                        if dst_obj_mask.ndim == 1:
+                            logger.info(f"converting 1d object mask {dst_obj} to 2d")
+                            dst_obj_mask = dst_obj_mask[:, None]
+                        if '?' in str(dst_obj_mask.type) or 'Option' in str(dst_obj_mask.type):
+                            assert not ak.any(ak.is_none(dst_obj_mask)), f"object mask {dst_obj} contains None values"
+                            logger.info(f"object mask {dst_obj} is of mixed type, but does not contain Nones: converting to pure type.")
+                            dst_obj_mask = ak.fill_none(dst_obj_mask, 0)
+                        dst_objects[dst_obj] = ak.from_regular(dst_obj_mask)  # make sure object masks are jagged to avoid numpy index
         self.objects = DotDict.wrap(objects or {})
         self.other = DotDict.wrap(other)
 


### PR DESCRIPTION
- event mask should be a 1d Array of booleans
- object masks should be:
  -  a 2d Array of booleans
  - a 2d or 1d Array of integers 

All mask are checked for the presence of Nones (raising an error if found) and converted to pure type (no ? or option in the type).

Integer object masks are converted to be
- two dimensional (if original 1d, the user is notified about the conversion)
- jagged (type is of form <N * var * ... >, not <N * M * ... >)

These checks avoid errors like the following:
- objects mask is 1d integer: the object mask will be interpreted as an event index instead of an object index
- object mask is 2d integer, but of fixed dimensions (not jagged): the object mask might again be interpreted as selecting events, not obejcts
- event mask is a single boolean. For instance, when doing smth like ak.sum(leptons.pdgId == 11) == 1, which wil sum over all electrons in the entire sample because the axis=1 is omitted. The mask will most probably evaluate to False and kill all of your events.
- object mask is of mixed type in only one (part of a) datafile, but pure in others (because of rare none values), resulting in merging issues.