### PR TITLE
wildcards config.x.keep_columns, 

### DIFF
--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -130,17 +130,19 @@ class ReduceEvents(
             for src_field in sel_results.objects.fields:
                 for dst_field in sel_results.objects[src_field].fields:
                     # nothing to do in case the top level column does not need to be loaded
-                    if not law.util.multi_match(dst_field, write_columns_groups.keys()):
+                    matches = [wc for wc in write_columns_groups if law.util.multi_match(dst_field, wc)]
+                    if not matches:
                         continue
                     # register the object masks
                     read_sel_columns.add(Route(f"objects.{src_field}.{dst_field}"))
                     # in case new collections are created and configured to be written, make sure
                     # that the corresponding columns of the source collection are loaded
                     if src_field != dst_field:
-                        read_columns |= {
-                            src_field + route[1:]
-                            for route in write_columns_groups[dst_field]
-                        }
+                        for wc in matches:
+                            read_columns |= {
+                                src_field + route[1:]
+                                for route in write_columns_groups[wc]
+                            }
         del sel_results
 
         # event counters


### PR DESCRIPTION
for wildcards used in config.x.keep_columns, columnflow did not load the source_fields properly. For instance I had the object mask:
```
{
    'GenPart': {
        'GenStTop': ...,
        'GenStBottom': ...,
    }
}
```

and in config.x.keep_columns I had included `four_vec('GenSt*', 'pdgId')`

Columnflow would then not load 'GenPart' and the reduction therefore failed.
